### PR TITLE
Expose blur method

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -66,6 +66,7 @@ interface Props extends TextInputProps {
 
 interface InputRef {
   focus(): void;
+  blur(): void;
 }
 
 const FloatingLabelInput: React.RefForwardingComponent<InputRef, Props> = (
@@ -87,6 +88,9 @@ const FloatingLabelInput: React.RefForwardingComponent<InputRef, Props> = (
     focus() {
       inputRef.current.focus();
     },
+    blur() {
+      inputRef.current.blur();
+    }
   }));
 
   function handleFocus() {


### PR DESCRIPTION
It would be nice if the `blur` method was exposed as well so the input field can be programmatically blurred.