### PR TITLE
Update index.tsx

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -279,7 +279,7 @@ const FloatingLabelInput: React.ForwardRefRenderFunction<InputRef, Props> = (
       Animated.timing(topAnimated, {
         toValue: customLabelStyles.topFocused
           ? customLabelStyles.topFocused
-          : -halfTop / 2,
+          : -halfTop,
         duration: 300,
         easing: Easing.linear,
         useNativeDriver: true,


### PR DESCRIPTION
having trouble with multiline input, label was hiding behind textInput because we are dividing halfTop with 2 when its not a static label.