### PR TITLE
Password show/hide toggle doesn't focus input field

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -418,11 +418,9 @@ const FloatingLabelInput: React.ForwardRefRenderFunction<InputRef, Props> = (
     if (onTogglePassword) {
       onTogglePassword(!secureText);
     }
-    if (secureText) {
-      setSecureText(false);
-    } else {
-      setSecureText(true);
-    }
+
+    setSecureText(!secureText);
+    secureText && setFocus();
   }
 
   function onSubmitEditing() {


### PR DESCRIPTION
Currently when we use the Password props for the input field, like:
```
<FloatingLabelInput
  label="Password"
  value={password}
  isPassword={true}
  onChangeText={text => setPassword(text)}
  customShowPasswordImage={showPassword}
  customHidePasswordImage={hidePassword}
/>
```

Every time when we click the show/hide component, the `setFocus` is not called when we display the password (this is a normal behavior we should expect in the input field)