### PR TITLE
fix typescript error

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -529,7 +529,7 @@ const FloatingLabelInput: React.ForwardRefRenderFunction<InputRef, Props> = (
         let unmasked = val.replace(/[^0-9A-Za-z]/g, '');
 
         // pegar as posições dos caracteres especiais.
-        let positions = [];
+        let positions: number[] = [];
         for (let i = 0; i < mask.length; i++) {
           if (mask[i].match(/[^0-9A-Za-z]/)) {
             positions.push(i);


### PR DESCRIPTION
This PR fixes a typescript type check issue;

> `react-native-floating-label-input/src/index.tsx:535:28 - error TS2345: Argument of type 'number' is not assignable to parameter of type 'never'.`
> `535             positions.push(i);`                            
> `Found 1 error.`
