### PR TITLE
fix: label prop type to `React.ReactNode`

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -50,7 +50,7 @@ export interface Props extends Omit<TextInputProps, 'secureTextEntry'> {
   /** Set the color to the hint */
   hintTextColor?: string;
   /** Value for the label, same as placeholder */
-  label: string;
+  label: React.ReactNode;
   /** Style to the label */
   labelStyles?: TextStyle;
   /** Set this to true if is password to have a show/hide input and secureTextEntry automatically */


### PR DESCRIPTION
Currently, the `label` type is a String, but it should instead be `React.ReactNode`, so we can pass fragments and other components to the label prop, like this:

```jsx
<FloatingLabelInput 
  label={<>My label:<Text style={{ color: 'tomato' }}>*</Text></>}
  {...otherProps}
/>
```

`React.ReactNode` is the default type for the `<Text />`'s children prop, and it also accepts a string as well.